### PR TITLE
fix: wrong import for motion library

### DIFF
--- a/game/components/wordInput.tsx
+++ b/game/components/wordInput.tsx
@@ -1,4 +1,4 @@
-import { AnimatePresence, motion } from 'framer-motion';
+import { AnimatePresence, motion } from 'motion/react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { cn } from '../utils';
 


### PR DESCRIPTION
During Migration from framer-motion to motion library there appeared to be wrongly imported snippet remaining in the word input component